### PR TITLE
Enable Certificate Verification

### DIFF
--- a/src/LiveChat/Api/Rest/RestRequest.php
+++ b/src/LiveChat/Api/Rest/RestRequest.php
@@ -260,7 +260,7 @@ class RestRequest
             $headers[] = "$key: $value";
         }
 
-        curl_setopt($curlHandle, CURLOPT_SSL_VERIFYPEER, FALSE);
+        curl_setopt($curlHandle, CURLOPT_SSL_VERIFYPEER, true);
         curl_setopt($curlHandle, CURLOPT_SSL_VERIFYHOST, 2);
         curl_setopt($curlHandle, CURLOPT_TIMEOUT, 15);
         curl_setopt($curlHandle, CURLOPT_URL, $this->url);


### PR DESCRIPTION
Peer verification should ALWAYS be enabled. Disabling it prevents authenticity checks and allows anyone with a certificate to impersonate livechat in a man in the middle attack.

- https://secure.php.net/manual/en/function.curl-setopt.php#110457
- https://stackoverflow.com/questions/21195530/does-turning-off-curlopt-ssl-verifypeer-in-curl-make-transmission-insecure
- https://stackoverflow.com/questions/4660610/if-curlopt-ssl-verifypeer-is-false-is-the-data-transfer-no-longer-secure
- https://snippets.webaware.com.au/howto/stop-turning-off-curlopt_ssl_verifypeer-and-fix-your-php-config/